### PR TITLE
Add bitwise operators

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -646,6 +646,18 @@ impl Codegen {
             AstNode::Or => {
                 output.extend_from_slice(b"||");
             }
+            AstNode::BitwiseAnd => {
+                output.extend_from_slice(b"&");
+            }
+            AstNode::BitwiseOr => {
+                output.extend_from_slice(b"|");
+            }
+            AstNode::ShiftLeft => {
+                output.extend_from_slice(b"<<");
+            }
+            AstNode::ShiftRight => {
+                output.extend_from_slice(b">>");
+            }
             AstNode::GreaterThanOrEqual => {
                 output.extend_from_slice(b">=");
             }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1740,7 +1740,14 @@ impl Typechecker {
                 let op = *op;
 
                 match self.compiler.get_node(op) {
-                    AstNode::Plus | AstNode::Minus | AstNode::Multiply | AstNode::Divide => {
+                    AstNode::Plus
+                    | AstNode::Minus
+                    | AstNode::Multiply
+                    | AstNode::Divide
+                    | AstNode::ShiftLeft
+                    | AstNode::ShiftRight
+                    | AstNode::BitwiseAnd
+                    | AstNode::BitwiseOr => {
                         let lhs_ty = self.typecheck_node(lhs, local_inferences);
                         let rhs_ty = self.typecheck_node(rhs, local_inferences);
                         if !self.unify_types(lhs_ty, rhs_ty, local_inferences) {

--- a/tests/integration/math/bitwise.june
+++ b/tests/integration/math/bitwise.june
@@ -1,0 +1,6 @@
+// output: 1613
+
+println(3 >> 1)
+println(3 << 1)
+println(3 & 1)
+println(3 | 2)


### PR DESCRIPTION
Add support for some common bitwise operators:

```rust
println(3 >> 1)
println(3 << 1)
println(3 & 1)
println(3 | 2)
```